### PR TITLE
Added more buffer manipulations 

### DIFF
--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -228,7 +228,9 @@ BitBuffer.prototype = {
       }
     } 
   },
-  _throwRangeError: function(){throw new Error("RangeError");},
+  _throwRangeError: function() {
+    throw new RangeError("Invalid width for requested type");
+  },
   
   resize: function(bitSize) {
     var

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -1,34 +1,54 @@
 "use strict"
+var os = require('os');
 
 function BitBuffer(number, buffer) {
 	var size = Math.ceil(number / 8)
+  
 	if (buffer != undefined && buffer.length == size) {
 		this.buffer = buffer
 	} else {
 		this.buffer = new Buffer(size)
 		this.buffer.fill(0)
 	}
+  this.maxByteIndex = this.buffer.length - 1;
+  this.size = this.buffer.length * 8;
+  
+  /*
+    If this is a little endian system, byte 0 would be on the left hand side
+    of the buffer. However, since this is supposed to represend a bit array,
+    we should foce a big endian layout by reversing the byte order so byte 0
+    is on the right. 
+  */
+  this._byteIndex = os.endianness() == "LE" ?
+    this._byteIndexLE : this._byteIndexBE; 
 }
 
 
 BitBuffer.prototype = {
 	set: function(index, bool) {
-		var pos = index >>> 3
 		if(bool) {
-			this.buffer[pos] |= 1 << (index % 8)
+			this.buffer[this._byteIndex(index)] |= 1 << (index % 8);
 		} else {
-			this.buffer[pos] &= ~(1 << (index % 8))
+			this.buffer[this._byteIndex(index)] &= ~(1 << (index % 8));
 		}
 	},
 	get: function(index) {
-		return (this.buffer[index >>> 3] & (1 << (index % 8))) != 0
+    return (this.buffer[this._byteIndex(index)] & (1 << (index % 8))) != 0;
 	},
 	toggle: function(index) {
-		this.buffer[index >>> 3] ^= 1 << (index % 8)
+		this.buffer[this._byteIndex(index)] ^= 1 << (index % 8);
 	},
 	toBuffer: function() {
 		return this.buffer
-	}
+	},
+  
+  _byteIndex: null,
+  _byteIndexLE: function(index) {
+    return this.maxByteIndex - (index >>> 3);
+  },
+  _byteIndexBE: function(index) {
+    return index >>> 3;
+  }
 }
 
 exports.BitBuffer = BitBuffer

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -188,7 +188,23 @@ BitBuffer.prototype = {
     return this;
   },
   subbuffer: function(begin, end) {
-    return (new BitBuffer()).fromBitArray(this.toBitArray().slice(begin, end));
+    var newbuff, size; 
+    
+    //make sure begin and end are valid
+    begin = isFinite(+begin) ? begin : 0,
+    end = isFinite(+end) ? +end : this.size;
+    begin = begin >= 0 ? begin : 0;
+    end = end <= this.size ? end : this.size;
+    size = end - begin;
+    if (size < 1) {
+      return new BitBuffer(0);
+    }
+    
+    newbuff = new BitBuffer(size);
+    for (var bit_i = 0; bit_i < size; bit_i++) {
+      newbuff.set(bit_i, this.get(bit_i + begin));
+    }
+    return newbuff;
   },
   shiftRight: function(shiftBits) {
     if (shiftBits < 0) {

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -142,6 +142,43 @@ BitBuffer.prototype = {
   subbuffer: function(begin, end) {
     return (new BitBuffer()).fromBitArray(this.toBitArray().slice(begin, end));
   },
+  shiftRight: function(shiftBits) {
+    if (shiftBits < 0) {
+      return this.shiftLeft(-shiftBits);
+    }
+    
+    var bitarr = this.toBitArray();
+    
+    while (shiftBits--) {
+      //shift the bits off the "front" of the array
+      //array index 0 is at the front, which corresponds to 
+      //LSB on the right of the bit string
+      bitarr.shift();
+      bitarr.push(0);
+    }
+    
+    this.fromBitArray(bitarr);
+    
+    return this;
+  },
+  shiftLeft: function(shiftBits) {
+    if (shiftBits < 0) {
+      return this.shiftRight(-shiftBits);
+    }
+    
+    var bitarr = this.toBitArray();
+    
+    while (shiftBits--) {
+      //unshift empty bits onto the front of the array
+      //and pop the extra bit off the end
+      bitarr.unshift(0);
+      bitarr.pop();
+    }
+    
+    this.fromBitArray(bitarr);
+    
+    return this;
+  },
   _byteIndex: null,
   _byteIndexLE: function(index) {
     return this.maxByteIndex - (index >>> 3);

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -89,7 +89,7 @@ BitBuffer.prototype = {
       bitSize = bitstr.length,
       bitarr = [];
     
-    while (--bitSize) {
+    while (bitSize--) {
       bitarr.push(!!+bitstr[bitSize]);
     }
     

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -150,7 +150,6 @@ BitBuffer.prototype = {
       hexstr;
     
     while (byte_i--) {
-      console.log(this.buffer[byte_i].toString(16));
       hexarr.push(
         (this.buffer[byte_i] < 0x10 ? "0" : "") +
         this.buffer[byte_i].toString(16)
@@ -158,8 +157,11 @@ BitBuffer.prototype = {
     }
     
     hexstr = hexarr.join("");
- 
-    return hexstr;
+   
+    //the string will be in whole bytes.
+    //However, if our bit buffer size is not in whole bytes,
+    //we should chop off any leading nybbles before returning
+    return hexstr.substring(hexstr.length - (Math.ceil(this.size / 4)));
   },
   
   toNumber: function() {

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -150,7 +150,11 @@ BitBuffer.prototype = {
       hexstr;
     
     while (byte_i--) {
-      hexarr.push(this.buffer[byte_i].toString(16));
+      console.log(this.buffer[byte_i].toString(16));
+      hexarr.push(
+        (this.buffer[byte_i] < 0x10 ? "0" : "") +
+        this.buffer[byte_i].toString(16)
+      );
     }
     
     hexstr = hexarr.join("");

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -42,6 +42,22 @@ BitBuffer.prototype = {
   toBuffer: function() {
 		return this.buffer
 	},
+  
+  fromBitArray: function(bitarr, resize) {
+    var
+      bitSize = bitarr.length,
+      byteSize = Math.ceil(bitSize / 8);
+    
+    if (resize && byteSize != this.buffer.length) {
+      this.resize(bitSize);
+    }
+    
+    bitarr.forEach(function(bit, bit_i){
+      this.set(bit_i, bit)
+    }, this);
+    
+    return this;
+  },
   toBitArray: function(bitOrder) {
     var
       size = this.size,
@@ -60,6 +76,19 @@ BitBuffer.prototype = {
     }
     
     return boolarr;
+  },
+  
+  fromBinaryString: function(bitstr, resize) {
+    //treat the string as an array of bits that has been indexed backwards
+    var
+      bitSize = bitstr.length,
+      bitarr = [];
+    
+    while (--bitSize) {
+      bitarr.push(!!+bitstr[bitSize]);
+    }
+    
+    return this.fromBitArray(bitarr, resize);
   },
   toBinaryString: function() {
     return this.toBitArray(-1).join("");

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -139,6 +139,9 @@ BitBuffer.prototype = {
     
     return this;
   },
+  subbuffer: function(begin, end) {
+    return (new BitBuffer()).fromBitArray(this.toBitArray().slice(begin, end));
+  },
   _byteIndex: null,
   _byteIndexLE: function(index) {
     return this.maxByteIndex - (index >>> 3);

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -129,7 +129,7 @@ BitBuffer.prototype = {
     
     this.buffer = newbuff;
     this.maxByteIndex = newbuff.length - 1;
-    this.size = newSize;
+    this.size = bitSize;
     
     if (bitSize % 8 != 0) {
       //zero out any bits beyond the specified size in the last byte

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -43,12 +43,12 @@ BitBuffer.prototype = {
 		return this.buffer
 	},
   
-  fromBitArray: function(bitarr, resize) {
+  fromBitArray: function(bitarr, noresize) {
     var
       bitSize = bitarr.length,
       byteSize = Math.ceil(bitSize / 8);
     
-    if (resize && byteSize != this.buffer.length) {
+    if (!noresize && byteSize != this.buffer.length) {
       this.resize(bitSize);
     }
     
@@ -78,7 +78,7 @@ BitBuffer.prototype = {
     return boolarr;
   },
   
-  fromBinaryString: function(bitstr, resize) {
+  fromBinaryString: function(bitstr, noresize) {
     //treat the string as an array of bits that has been indexed backwards
     var
       bitSize = bitstr.length,
@@ -88,7 +88,7 @@ BitBuffer.prototype = {
       bitarr.push(!!+bitstr[bitSize]);
     }
     
-    return this.fromBitArray(bitarr, resize);
+    return this.fromBitArray(bitarr, noresize);
   },
   toBinaryString: function() {
     return this.toBitArray(-1).join("");

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -214,64 +214,64 @@ BitBuffer.prototype = {
   _getTypedValueLE : {
     uint: {
       8: function(bytebuff){
-        return bytebuff.readUInt8();
+        return bytebuff.readUInt8(0);
       },
       16: function(bytebuff){
-        return bytebuff.readUInt16LE();
+        return bytebuff.readUInt16LE(0);
       },
       32: function(bytebuff){
-        return bytebuff.readUInt32LE();
+        return bytebuff.readUInt32LE(0);
       }
     },
     int: {
       8: function(bytebuff){
-        return bytebuff.readInt8();
+        return bytebuff.readInt8(0);
       },
       16: function(bytebuff){
-        return bytebuff.readInt16LE();
+        return bytebuff.readInt16LE(0);
       },
       32: function(bytebuff){
-        return bytebuff.readInt32LE();
+        return bytebuff.readInt32LE(0);
       }
     },
     float: { 
       32: function(bytebuff){
-        return bytebuff.readFloatLE();
+        return bytebuff.readFloatLE(0);
       },
       64: function(bytebuff){
-        return bytebuff.readDoubleLE();
+        return bytebuff.readDoubleLE(0);
       }
     } 
   },
   _getTypedValueBE : {
     uint: {
       8: function(bytebuff){
-        return bytebuff.readUInt8();
+        return bytebuff.readUInt8(0);
       },
       16: function(bytebuff){
-        return bytebuff.readUInt16BE();
+        return bytebuff.readUInt16BE(0);
       },
       32: function(bytebuff){
-        return bytebuff.readUInt32BE();
+        return bytebuff.readUInt32BE(0);
       }
     },
     int: {
       8: function(bytebuff){
-        return bytebuff.readInt8();
+        return bytebuff.readInt8(0);
       },
       16: function(bytebuff){
-        return bytebuff.readInt16BE();
+        return bytebuff.readInt16BE(0);
       },
       32: function(bytebuff){
-        return bytebuff.readInt32BE();
+        return bytebuff.readInt32BE(0);
       }
     },
     float: { 
       32: function(bytebuff){
-        return bytebuff.readFloatBE();
+        return bytebuff.readFloatBE(0);
       },
       64: function(bytebuff){
-        return bytebuff.readDoubleBE();
+        return bytebuff.readDoubleBE(0);
       }
     } 
   },

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -101,7 +101,7 @@ BitBuffer.prototype = {
       newbuff;
       
     if (!isFinite(newSize) || oldSize == newSize) {
-      return;
+      return this;
     }
     
     newbuff = (new Buffer(newSize)).fill(0);

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -158,7 +158,7 @@ BitBuffer.prototype = {
     //the string will be in whole bytes.
     //However, if our bit buffer size is not in whole bytes,
     //we should chop off any leading nybbles before returning
-    return hexstr.substring(hexstr.length - ((this.size / 4) >> 0));
+    return hexstr;
   },
   
   toNumber: function() {

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -99,6 +99,49 @@ BitBuffer.prototype = {
   toBinaryString: function() {
     return this.toBitArray(-1).join("");
   },
+ 
+  fromHexString: function(hexstr, noresize) {
+    //treat the string as an array of bits that has been indexed backwards
+    var
+      nybbleSize = hexstr.length,
+      byteSize = Math.ceil(nybbleSize / 2),
+      bitSize = nybbleSize << 2;
+    
+    if (nybbleSize < 1) {
+      return this.resize(0);
+    }
+    
+    //clear out the buffer
+    if (noresize || byteSize == this.buffer.length) {
+      this.buffer.fill(0);
+    } else {
+      this.buffer = new Buffer(byteSize);
+      this.buffer.fill(0);
+      this.maxByteIndex = byteSize - 1;
+      this.size = bitSize;
+    }
+    
+    //pad the hex string if it does not contain an integer number of bytes
+    if (nybbleSize % 2 != 0) {
+      hexstr = "0" + hexstr;
+      nybbleSize++;
+      bitSize += 4;
+    }
+    
+    for (var bit_i=bitSize-1, nyb_i=0; nyb_i < nybbleSize; bit_i-=8, nyb_i+=2) {
+      this.buffer[this._byteIndex(bit_i)]=+("0x"+hexstr[nyb_i]+hexstr[nyb_i+1]);
+    }
+    
+    return this;
+  },
+  toHexString: function() {
+    var hexstr = this.buffer.toString("hex");
+    
+    //the string will be in whole bytes.
+    //However, if our bit buffer size is not in whole bytes,
+    //we should chop off any leading nybbles before returning
+    return hexstr.substring(hexstr.length - ((this.size / 4) >> 0));
+  },
   
   resize: function(bitSize) {
     var

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -98,9 +98,9 @@ BitBuffer.prototype = {
     var
       oldSize = this.buffer.length,
       newSize = Math.ceil(bitSize / 8),
-      newbuff;
+      newbuff, lastByte;
       
-    if (!isFinite(newSize) || oldSize == newSize) {
+    if (!isFinite(newSize)) {
       return this;
     }
     
@@ -123,6 +123,12 @@ BitBuffer.prototype = {
     this.buffer = newbuff;
     this.maxByteIndex = newbuff.length - 1;
     this.size = newbuff.length * 8;
+    
+    if (bitSize % 8 != 0) {
+      //zero out any bits beyond the specified size in the last byte
+      lastByte = this._byteIndex(bitSize);
+      newbuff[lastByte] = newbuff[lastByte] & (Math.pow(2, bitSize)-1);
+    }
     
     return this;
   },

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -52,7 +52,8 @@ BitBuffer.prototype = {
     if (noresize || byteSize == this.buffer.length) {
       this.buffer.fill(0);
     } else {
-      this.buffer = new Buffer(byteSize).fill(0);
+      this.buffer = new Buffer(byteSize)
+      this.buffer.fill(0);
       this.maxByteIndex = byteSize - 1;
       this.size = this.buffer.length * 8;
     }
@@ -109,7 +110,8 @@ BitBuffer.prototype = {
       return this;
     }
     
-    newbuff = (new Buffer(newSize)).fill(0);
+    newbuff = new Buffer(newSize);
+    newbuff.fill(0);
     
     if (newSize > oldSize) {
       //if this is an LE system, we need to make sure the start byte is offset

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -279,11 +279,11 @@ BitBuffer.prototype = {
     throw new RangeError("Invalid width for requested type.");
   },
   
-  resize: function(bitSize, propagateSignBit) {
+  resize: function(newBitSize, propagateSignBit) {
     var
       oldSignBit = this.size - 1,
       oldByteSize = this.buffer.length,
-      newByteSize = Math.ceil(bitSize / 8),
+      newByteSize = Math.ceil(newBitSize / 8),
       newbuff, lastByte, sign;
 
     if (!isFinite(newByteSize)) {
@@ -303,22 +303,22 @@ BitBuffer.prototype = {
       this.buffer = this.buffer.slice(0, newByteSize);
     }
     
-    if (this.size < bitSize) {
+    if (this.size < newBitSize) {
       //since we are growing, we might need to move the sign bit up
       if (propagateSignBit && this.get(oldSignBit)) {
-        this.set(bitSize - 1, 1);
+        this.set(newBitSize - 1, 1);
         this.set(oldSignBit, 0);
       }
     }
 
     //update the size properties
     this.maxByteIndex = this.buffer.length - 1;
-    this.size = bitSize;
+    this.size = newBitSize;
 
-    if (bitSize % 8 != 0) {
+    if (newBitSize % 8 != 0) {
       //zero out any bits beyond the specified size in the last byte
-      lastByte = bitSize >>> 3;
-      newbuff[lastByte] = newbuff[lastByte] & (Math.pow(2, bitSize)-1);
+      lastByte = newBitSize >>> 3;
+      newbuff[lastByte] = newbuff[lastByte] & (Math.pow(2, newBitSize)-1);
     }
     
     return this;

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -88,13 +88,28 @@ BitBuffer.prototype = {
     //treat the string as an array of bits that has been indexed backwards
     var
       bitSize = bitstr.length,
-      bitarr = [];
+      byteSize = Math.ceil(bitSize / 8),
+      bit_i = 0;
     
+    if (bitSize < 1) {
+      return this.resize(0);
+    }
+
+    //clear out the buffer
+    if (noresize || byteSize == this.buffer.length) {
+      this.buffer.fill(0);
+    } else {
+      this.buffer = new Buffer(byteSize)
+      this.buffer.fill(0);
+      this.maxByteIndex = byteSize - 1;
+      this.size = bitSize;
+    }
+
     while (bitSize--) {
-      bitarr.push(!!+bitstr[bitSize]);
+      this.set(bit_i++, !!+bitstr[bitSize]);
     }
     
-    return this.fromBitArray(bitarr, noresize);
+    return this;
   },
   toBinaryString: function() {
     return this.toBitArray(-1).join("");

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -163,7 +163,7 @@ BitBuffer.prototype = {
   },
   
   getValue: function(offset, type, width) {
-    var propagateSign, bitbuff;
+    var bitbuff;
     
     if (this.size == 0) {
       return 0;

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -65,6 +65,38 @@ BitBuffer.prototype = {
     return this.toBitArray(-1).join("");
   },
   
+  resize: function(bitSize) {
+    var
+      oldSize = this.buffer.length,
+      newSize = Math.ceil(bitSize / 8),
+      newbuff;
+      
+    if (!isFinite(newSize) || oldSize == newSize) {
+      return;
+    }
+    
+    newbuff = (new Buffer(newSize)).fill(0);
+    
+    if (newSize > oldSize) {
+      //if this is an LE system, we need to make sure the start byte is offset
+      //so the extra size will come in on the left side
+      this.buffer.copy(
+        newbuff, (os.endianness() == "LE" ? newSize - oldSize : 0), 0, oldSize
+      );
+    } else {
+      //if this is an LE system, we need to make sure the start byte is offset
+      //so the bit field will be trucated on the left
+      this.buffer.copy(
+        newbuff, 0, (os.endianness() == "LE" ? oldSize - newSize : 0), oldSize
+      );
+    }
+    
+    this.buffer = newbuff;
+    this.maxByteIndex = newbuff.length - 1;
+    this.size = newbuff.length * 8;
+    
+    return this;
+  },
   _byteIndex: null,
   _byteIndexLE: function(index) {
     return this.maxByteIndex - (index >>> 3);

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -47,9 +47,14 @@ BitBuffer.prototype = {
     var
       bitSize = bitarr.length,
       byteSize = Math.ceil(bitSize / 8);
-    
-    if (!noresize && byteSize != this.buffer.length) {
-      this.resize(bitSize);
+
+    //clear out the buffer
+    if (noresize || byteSize == this.buffer.length) {
+      this.buffer.fill(0);
+    } else {
+      this.buffer = new Buffer(byteSize).fill(0);
+      this.maxByteIndex = byteSize - 1;
+      this.size = this.buffer.length * 8;
     }
     
     bitarr.forEach(function(bit, bit_i){

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -38,9 +38,32 @@ BitBuffer.prototype = {
 	toggle: function(index) {
 		this.buffer[this._byteIndex(index)] ^= 1 << (index % 8);
 	},
-	toBuffer: function() {
+	
+  toBuffer: function() {
 		return this.buffer
 	},
+  toBitArray: function(bitOrder) {
+    var
+      size = this.size,
+      maxBit = size - 1,
+      boolarr = [];
+    
+    if (bitOrder < 0) {
+      //bitOrder can be set to a negative number to reverse the bit array
+      for (var bit_i = 0; bit_i < size; bit_i++) {
+        boolarr[maxBit - bit_i] = +!!this.get(bit_i);
+      }
+    } else {
+      for (var bit_i = 0; bit_i < size; bit_i++) {
+        boolarr[bit_i] = +!!this.get(bit_i);
+      }
+    }
+    
+    return boolarr;
+  },
+  toBinaryString: function() {
+    return this.toBitArray(-1).join("");
+  },
   
   _byteIndex: null,
   _byteIndexLE: function(index) {

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -11,7 +11,7 @@ function BitBuffer(number, buffer) {
 		this.buffer.fill(0)
 	}
   this.maxByteIndex = this.buffer.length - 1;
-  this.size = this.buffer.length * 8;
+  this.size = number;
   
   /*
     If this is a little endian system, byte 0 would be on the left hand side
@@ -55,7 +55,7 @@ BitBuffer.prototype = {
       this.buffer = new Buffer(byteSize)
       this.buffer.fill(0);
       this.maxByteIndex = byteSize - 1;
-      this.size = this.buffer.length * 8;
+      this.size = bitSize;
     }
     
     bitarr.forEach(function(bit, bit_i){
@@ -129,7 +129,7 @@ BitBuffer.prototype = {
     
     this.buffer = newbuff;
     this.maxByteIndex = newbuff.length - 1;
-    this.size = newbuff.length * 8;
+    this.size = newSize;
     
     if (bitSize % 8 != 0) {
       //zero out any bits beyond the specified size in the last byte

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -164,6 +164,27 @@ BitBuffer.prototype = {
     return hexstr.substring(hexstr.length - (Math.ceil(this.size / 4)));
   },
   
+  fromUInt: function(num) {
+    var byteSize, bitSize, buff;
+    
+    if (num > Number.MAX_SAFE_INTEGER) {
+      throw RangeError();
+    }
+    
+    bitSize = num < 0x100 ? 8 : num < 0x10000 ? 16 : num < 0x100000000 ? 32 : 64;
+    buff = new BitBuffer(bitSize);
+    
+    byteSize = buff.buffer.length;
+    for(var byte_i = 0, offset = 0; byte_i < byteSize; byte_i++, offset += 8) {
+      buff.buffer[byte_i] = (num >> offset) & 0xff;
+    }
+    
+    this.buffer = buff.buffer;
+    this.size = buff.size;
+    this.maxByteIndex = buff.maxByteIndex;
+    
+    return this
+  },
   toNumber: function() {
     return +("0x" + this.toHexString());
   },

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,11 @@ A bit array, backed by node.js Buffer
 	b.get(7) // true
 	console.log(b.toBinaryString()) //"101101111000"
 	
+	//create a sub-buffer of the current buffer
+	b = (new BitBuffer()).fromBinaryString("101100111000");
+	c= b.subbuffer(3, 8)
+	console.log(c.toBinaryString()) //"00111"
+	
 	//create an a boolean array with one bit per element
 	b = (new BitBuffer()).fromBinaryString("101100111000");
 	b.toBitArray();   //[0,0,0,1,1,1,0,0,1,1,0,1] LSB is at array index=0

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,61 @@ A bit array, backed by node.js Buffer
 	npm install bitbuffer
 
 ## Usage
-
-	var BitBuffer = require('bitbuffer').BitBuffer
-	var b = new BitBuffer(10)
+    var BitBuffer = require('bitbuffer').BitBuffer
+	var b;
+	
+    //create an empty buffer and flip some bits
+	b = new BitBuffer(10)
 	b.get(7) // false
 	b.set(7, true)
 	b.get(7) // true
 	b.toggle(7)
 	b.get(7) // false
+    
+	//create a buffer from a hex string
+	b = (new BitBuffer()).fromHexString("aaa");
+	b.set(8, true)
+	b.set(9, true)
+	b.set(10, true)
+	b.set(11, true)
+	console.log(b.toHexString()) //"faa"
+	
+	//create a buffer from a binary string
+	b = (new BitBuffer()).fromBinaryString("101100111000");
+	b.get(7) //false
+	b.set(7, true)
+	b.get(7) // true
+	console.log(b.toBinaryString()) //"101101111000"
+	
+	//create an a boolean array with one bit per element
+	b = (new BitBuffer()).fromBinaryString("101100111000");
+	b.toBitArray();   //[0,0,0,1,1,1,0,0,1,1,0,1] LSB is at array index=0
+	b.toBitArray(-1); //[1,0,1,1,0,0,1,1,1,0,0,0] LSB is at array index=(arr.length-1)
+	
+	create a buffer from a bit array
+	b = (new BitBuffer()).fromBitArray([0,0,0,1,1,1,0,0,1,1,0,1]);
+	b.toBinaryString(); // "101100111000" LSB is at array index=0
+	
+	//create a buffer from a binary string and shift
+	b = (new BitBuffer()).fromBinaryString("111111");
+	b.shiftRight(2)
+	console.log(b.toBinaryString()) //"001111"
+	b.shiftLeft(2)
+	console.log(b.toBinaryString()) //"111100"
+	
+	//resize a buffer
+	b = (new BitBuffer()).fromBinaryString("111111");
+	b.resize(9)
+	console.log(b.toBinaryString()) //"000111111"
+	
+	//get numeric value using getValue(offset, [type], [bitwidth])
+	b = (new BitBuffer()).fromBinaryString("10101");
+	b.getValue(2, "uint", 1) //1
+	b.getValue(0, "int", 3) //-3
+	b.getValue(0, "uint") //21
+	b.getValue(0, "int") //-11
+	b = (new BitBuffer()).fromHexString("4008000000000000");
+	b.getValue(0, "float") //0.0
+	b.getValue(0, "double") //3.0
+	
+	

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,11 @@ A bit array, backed by node.js Buffer
 	b.toggle(7)
 	b.get(7) // false
     
+	//create a buffer from uint
+	//if using hex format uint, must be a complete number of bytes
+	b = (new BitBuffer()).fromUInt(0xeb90);
+	console.log(b.toHexString()) //"eb90"
+	
 	//create a buffer from a hex string
 	b = (new BitBuffer()).fromHexString("aaa");
 	b.set(8, true)

--- a/test.js
+++ b/test.js
@@ -222,6 +222,6 @@ test('#getValue-rangeError', function() {
   assert.throws(
     function() {
       var b = (new BitBuffer(0)).getValue(0, 33, "int");
-    }, Error
+    }, RangeError
   )
 })

--- a/test.js
+++ b/test.js
@@ -102,7 +102,7 @@ test('#fromHexString', function() {
 
 test('#fromHexString-toHexString', function() {
   var b = (new BitBuffer()).fromHexString("b38f0");
-  assert.equal(b.toBinaryString(), "10110011100011110000");
+  assert.equal(b.toHexString(), "b38f0");
 })
 
 test('#fromHexString-toBinaryString-toBitArray-toHexString', function() {

--- a/test.js
+++ b/test.js
@@ -127,3 +127,52 @@ test('#fromHexString-toBinaryString-toBitArray-toHexString', function() {
     ).toHexString();
   assert.equal(inhexstr, outhexstr);
 })
+
+test('#resize-shrink', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000").resize(8);
+  
+  assert.equal(b.size, 8);
+  assert.equal(b.toBinaryString(), "11110000");
+})
+
+test('#resize-grow', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000").resize(24);
+  
+  assert.equal(b.size, 24);
+  assert.equal(b.toBinaryString(), "000010110011100011110000");
+})
+
+test('#resize-zero', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000").resize(0);
+  
+  assert.equal(b.size, 0);
+  assert.equal(b.toBinaryString(), "");
+})
+
+test('#shiftLeft', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  var size = b.size;
+  b.shiftLeft(5);
+  
+  assert.equal(b.size, size);
+  assert.equal(b.toBinaryString(), "01110001111000000000");
+})
+
+test('#shiftRight', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  var size = b.size;
+  b.shiftRight(5);
+  
+  assert.equal(b.size, size);
+  assert.equal(b.toBinaryString(), "00000101100111000111");
+})
+
+test('#subbuffer-full', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.subbuffer().toBinaryString(), "10110011100011110000");
+})
+
+test('#subbuffer-middle', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.subbuffer(5, 12).toBinaryString(), "1000111");
+})

--- a/test.js
+++ b/test.js
@@ -64,15 +64,6 @@ test('#bigone_4g', function() {
 	big(Math.pow(2,32) - 1)
 })
 
-test('#bigone_8g', function() {
-	assert.throws(
-		function() {
-      var b = new BitBuffer(Math.pow(2,33));
-		},
-		RangeError
-	)
-})
-
 test('#fromBitArray', function() {
   var bitarr = [0,0,0,0,1,1,1,1,0,0,0,1,1,1,0,0,1,1,0,1];
   var b = (new BitBuffer()).fromBitArray(bitarr);

--- a/test.js
+++ b/test.js
@@ -181,3 +181,56 @@ test('#subbuffer-invalid', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
   assert.equal(b.subbuffer(12, 5).toBinaryString(), "");
 })
+
+test('#toNumber', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.toNumber(), 0b10110011100011110000);
+})
+
+test('#getValue-uint8', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.getValue(7, 3, "uint"), 0b00000001);
+})
+
+test('#getValue-uint16', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.getValue(0, 10, "uint"), 0b0000000011110000);
+})
+
+test('#getValue-uint32', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.getValue(0, 17, "uint"), 0b00000000000000010011100011110000);
+})
+
+test('#getValue-int8', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.getValue(7, 3, "int"), 0b00000001);
+})
+
+test('#getValue-int16', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.getValue(0, 10, "int"), 0b0000000011110000);
+})
+
+test('#getValue-int32', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.getValue(0, 17, "int"), 0b00000000000000010011100011110000);
+})
+
+test('#getValue-float32', function() {
+  var b = (new BitBuffer()).fromHexString("40400000");
+  assert.equal(b.getValue(0, 32, "float"), 3);
+})
+
+test('#getValue-float64', function() {
+  var b = (new BitBuffer()).fromHexString("4008000000000000");
+  assert.equal(b.getValue(0, 64, "float"), 3);
+})
+
+test('#getValue-rangeError', function() {
+  assert.throws(
+    function() {
+      var b = (new BitBuffer(0)).getValue(0, 33, "int");
+    }, Error
+  )
+})

--- a/test.js
+++ b/test.js
@@ -70,3 +70,58 @@ test('#bigone_8g', function() {
 		RangeError
 	)
 })
+
+test('#fromBitArray', function() {
+  var bitarr = [0,0,0,0,1,1,1,1,0,0,0,1,1,1,0,0,1,1,0,1];
+  var b = (new BitBuffer()).fromBitArray(bitarr);
+  bitarr.forEach(function(bit, bit_i) {
+    assert.equal(!!bit, !!b.get(bit_i))
+  }, this)
+})
+
+test('#fromBitArray-toBitArray', function() {
+  var inbitarr = [0,0,0,0,1,1,1,1,0,0,0,1,1,1,0,0,1,1,0,1];
+  var b = (new BitBuffer()).fromBitArray(inbitarr);
+  var outbitarr = b.toBitArray();
+  inbitarr.forEach(function(bit, bit_i) {
+    assert.equal(!!bit, !!outbitarr[bit_i])
+  }, this);
+})
+
+test('#fromBinaryString', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.buffer[endianness == "LE" ? 2 : 0], 0xf0);
+  assert.equal(b.buffer[1], 0x38);
+  assert.equal(b.buffer[endianness == "LE" ? 0 : 2], 0x0b);
+})
+
+test('#fromBinaryString-toBinaryString', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.toBinaryString(), "10110011100011110000");
+})
+
+test('#fromHexString', function() {
+  var b = (new BitBuffer()).fromHexString("b38f0");
+  assert.equal(b.buffer[endianness == "LE" ? 2 : 0], 0xf0);
+  assert.equal(b.buffer[1], 0x38);
+  assert.equal(b.buffer[endianness == "LE" ? 0 : 2], 0x0b);
+})
+
+test('#fromHexString-toHexString', function() {
+  var b = (new BitBuffer()).fromHexString("b38f0");
+  assert.equal(b.toBinaryString(), "10110011100011110000");
+})
+
+test('#fromHexString-toBinaryString-toBitArray-toHexString', function() {
+  var inhexstr = "b38f0";
+  var b = (new BitBuffer());
+  var outhexstr = 
+    b.fromBitArray(
+      b.fromBinaryString(
+        b.fromHexString(
+          inhexstr
+        ).toBinaryString()
+      ).toBitArray()
+    ).toHexString();
+  assert.equal(inhexstr, outhexstr);
+})

--- a/test.js
+++ b/test.js
@@ -176,3 +176,8 @@ test('#subbuffer-middle', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
   assert.equal(b.subbuffer(5, 12).toBinaryString(), "1000111");
 })
+
+test('#subbuffer-invalid', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.subbuffer(12, 5).toBinaryString(), "");
+})

--- a/test.js
+++ b/test.js
@@ -1,8 +1,21 @@
 "use strict"
 var assert = require("assert")
 var BitBuffer = require('./bitbuffer').BitBuffer
+var endianness = require('os').endianness();
 
-suite('BitBuffer')
+if (!test) {
+  var test = (
+    function test(name, testfun) {
+      try {
+        testfun();
+        console.log(name + ": PASSED");
+      } catch (e) {
+        console.error(name + ": Failed");
+        console.error(e);
+      }
+    }
+  );
+}
 
 test('#zeroinit', function() {
 	var b = new BitBuffer(10)
@@ -23,11 +36,16 @@ test('#set', function() {
 
 function big(bit) {
 	var b = new BitBuffer(bit + 1)
-	assert.equal(b.get(bit), false)
+  assert.equal(b.get(bit), false)
 	b.set(bit, true)
 	assert.equal(b.get(bit), true)
+  
+  var byte_i = (bit / 8)|0;
+  if (endianness == "LE") {
+    byte_i = b.buffer.length - byte_i - 1;
+  }
 	assert.equal(
-		(b.buffer[(bit / 8)|0] & (1 << (bit % 8))) != 0,
+		(b.buffer[byte_i] & (1 << (bit % 8))) != 0,
 		true
 	)
 }
@@ -47,9 +65,8 @@ test('#bigone_4g', function() {
 test('#bigone_8g', function() {
 	assert.throws(
 		function() {
-			b = new BitBuffer(Math.pow(2,33))
+      var b = new BitBuffer(Math.pow(2,33));
 		},
 		RangeError
 	)
 })
-

--- a/test.js
+++ b/test.js
@@ -33,8 +33,6 @@ function big(bit) {
 }
 
 test('#bigone_2852448540', function() {
-	var bit = 2852448540
-	var bit = Math.pow(2,31)
 	big(2852448540)
 })
 

--- a/test.js
+++ b/test.js
@@ -197,17 +197,17 @@ test('#getValue-uint32', function() {
 
 test('#getValue-int8', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(7,"int", 3), 0b00000001);
+  assert.equal(b.getValue(7,"int", 5), -127);
 })
 
 test('#getValue-int16', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, "int", 10), 0b0000000011110000);
+  assert.equal(b.getValue(0, "int", 12), -32528);
 })
 
 test('#getValue-int32', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, "int", 17), 0b00000000000000010011100011110000);
+  assert.equal(b.getValue(0, "int", 17), -2147469072);
 })
 
 test('#getValue-float32', function() {

--- a/test.js
+++ b/test.js
@@ -175,50 +175,65 @@ test('#toNumber', function() {
   assert.equal(b.toNumber(), 0b10110011100011110000);
 })
 
+test('#getValue-typeless-widthless', function() {
+  var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
+  assert.equal(b.getValue(7), 0b1011001110001);
+})
+
 test('#getValue-uint8', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(7, 3, "uint"), 0b00000001);
+  assert.equal(b.getValue(7, "uint", 3), 0b00000001);
 })
 
 test('#getValue-uint16', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, 10, "uint"), 0b0000000011110000);
+  assert.equal(b.getValue(0, "uint", 10), 0b0000000011110000);
 })
 
 test('#getValue-uint32', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, 17, "uint"), 0b00000000000000010011100011110000);
+  assert.equal(b.getValue(0, "uint", 17), 0b00000000000000010011100011110000);
 })
 
 test('#getValue-int8', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(7, 3, "int"), 0b00000001);
+  assert.equal(b.getValue(7,"int", 3), 0b00000001);
 })
 
 test('#getValue-int16', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, 10, "int"), 0b0000000011110000);
+  assert.equal(b.getValue(0, "int", 10), 0b0000000011110000);
 })
 
 test('#getValue-int32', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, 17, "int"), 0b00000000000000010011100011110000);
+  assert.equal(b.getValue(0, "int", 17), 0b00000000000000010011100011110000);
 })
 
 test('#getValue-float32', function() {
   var b = (new BitBuffer()).fromHexString("40400000");
-  assert.equal(b.getValue(0, 32, "float"), 3);
+  assert.equal(b.getValue(0, "float"), 3);
 })
 
 test('#getValue-float64', function() {
   var b = (new BitBuffer()).fromHexString("4008000000000000");
-  assert.equal(b.getValue(0, 64, "float"), 3);
+  assert.equal(b.getValue(0, "float", 64), 3);
+})
+
+test('#getValue-float', function() {
+  var b = (new BitBuffer()).fromHexString("40400000");
+  assert.equal(b.getValue(0, "float"), 3);
+})
+
+test('#getValue-double', function() {
+  var b = (new BitBuffer()).fromHexString("4008000000000000");
+  assert.equal(b.getValue(0, "double"), 3);
 })
 
 test('#getValue-rangeError', function() {
   assert.throws(
     function() {
-      var b = (new BitBuffer(0)).getValue(0, 33, "int");
+      var b = (new BitBuffer(5)).getValue(0, "int", 33);
     }, RangeError
   )
 })

--- a/test.js
+++ b/test.js
@@ -59,6 +59,11 @@ test('#bigone_4g', function() {
 	big(Math.pow(2,32) - 1)
 })
 
+test('#fromUInt', function() {
+  var b = (new BitBuffer()).fromUInt(0xeb90);
+  assert.equal(b.toHexString(), "eb90")
+})
+
 test('#fromBitArray', function() {
   var bitarr = [0,0,0,0,1,1,1,1,0,0,0,1,1,1,0,0,1,1,0,1];
   var b = (new BitBuffer()).fromBitArray(bitarr);

--- a/test.js
+++ b/test.js
@@ -172,42 +172,42 @@ test('#subbuffer-invalid', function() {
 
 test('#toNumber', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.toNumber(), 0b10110011100011110000);
+  assert.equal(b.toNumber(), 735472);//0b10110011100011110000
 })
 
 test('#getValue-typeless-widthless', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(7), 0b1011001110001);
+  assert.equal(b.getValue(7), 5745);//0b1011001110001
 })
 
 test('#getValue-uint8', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(7, "uint", 3), 0b00000001);
+  assert.equal(b.getValue(7, "uint", 3), 1)//0b00000001
 })
 
 test('#getValue-uint16', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, "uint", 10), 0b0000000011110000);
+  assert.equal(b.getValue(0, "uint", 10), 240);//0b0000000011110000;
 })
 
 test('#getValue-uint32', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, "uint", 17), 0b00000000000000010011100011110000);
+  assert.equal(b.getValue(0, "uint", 17), 80112);//0b00000000000000010011100011110000
 })
 
 test('#getValue-int8', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(7,"int", 5), -15);
+  assert.equal(b.getValue(7,"int", 5), -15);//0b11110001
 })
 
 test('#getValue-int16', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, "int", 12), -1808);
+  assert.equal(b.getValue(0, "int", 12), -1808);//0b1111100011110000
 })
 
 test('#getValue-int32', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, "int", 17), -50960);
+  assert.equal(b.getValue(0, "int", 17), -50960);//0b11111111111111110011100011110000
 })
 
 test('#getValue-float32', function() {

--- a/test.js
+++ b/test.js
@@ -41,10 +41,8 @@ function big(bit) {
 	b.set(bit, true)
 	assert.equal(b.get(bit), true)
   
-  var byte_i = (bit / 8)|0;
-  
 	assert.equal(
-		(b.buffer[byte_i] & (1 << (bit % 8))) != 0,
+		(b.buffer[(bit / 8)|0] & (1 << (bit % 8))) != 0,
 		true
 	)
 }

--- a/test.js
+++ b/test.js
@@ -197,17 +197,17 @@ test('#getValue-uint32', function() {
 
 test('#getValue-int8', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(7,"int", 5), -127);
+  assert.equal(b.getValue(7,"int", 5), -15);
 })
 
 test('#getValue-int16', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, "int", 12), -32528);
+  assert.equal(b.getValue(0, "int", 12), -1808);
 })
 
 test('#getValue-int32', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.getValue(0, "int", 17), -2147469072);
+  assert.equal(b.getValue(0, "int", 17), -50960);
 })
 
 test('#getValue-float32', function() {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,6 @@
 "use strict"
 var assert = require("assert")
 var BitBuffer = require('./bitbuffer').BitBuffer
-var endianness = require('os').endianness();
 
 var suite = suite || (function(){})
 
@@ -43,9 +42,7 @@ function big(bit) {
 	assert.equal(b.get(bit), true)
   
   var byte_i = (bit / 8)|0;
-  if (endianness == "LE") {
-    byte_i = b.buffer.length - byte_i - 1;
-  }
+  
 	assert.equal(
 		(b.buffer[byte_i] & (1 << (bit % 8))) != 0,
 		true
@@ -83,9 +80,9 @@ test('#fromBitArray-toBitArray', function() {
 
 test('#fromBinaryString', function() {
   var b = (new BitBuffer()).fromBinaryString("10110011100011110000");
-  assert.equal(b.buffer[endianness == "LE" ? 2 : 0], 0xf0);
+  assert.equal(b.buffer[0], 0xf0);
   assert.equal(b.buffer[1], 0x38);
-  assert.equal(b.buffer[endianness == "LE" ? 0 : 2], 0x0b);
+  assert.equal(b.buffer[2], 0x0b);
 })
 
 test('#fromBinaryString-toBinaryString', function() {
@@ -95,9 +92,9 @@ test('#fromBinaryString-toBinaryString', function() {
 
 test('#fromHexString', function() {
   var b = (new BitBuffer()).fromHexString("b38f0");
-  assert.equal(b.buffer[endianness == "LE" ? 2 : 0], 0xf0);
+  assert.equal(b.buffer[0], 0xf0);
   assert.equal(b.buffer[1], 0x38);
-  assert.equal(b.buffer[endianness == "LE" ? 0 : 2], 0x0b);
+  assert.equal(b.buffer[2], 0x0b);
 })
 
 test('#fromHexString-toHexString', function() {

--- a/test.js
+++ b/test.js
@@ -3,19 +3,21 @@ var assert = require("assert")
 var BitBuffer = require('./bitbuffer').BitBuffer
 var endianness = require('os').endianness();
 
-if (!test) {
-  var test = (
-    function test(name, testfun) {
-      try {
-        testfun();
-        console.log(name + ": PASSED");
-      } catch (e) {
-        console.error(name + ": Failed");
-        console.error(e);
-      }
+var suite = suite || (function(){})
+
+var test = test || (
+  function test(name, testfun) {
+    try {
+      testfun();
+      console.log(name + ": PASSED");
+    } catch (e) {
+      console.error(name + ": Failed");
+      console.error(e);
     }
-  );
-}
+  }
+);
+
+suite('BitBuffer')
 
 test('#zeroinit', function() {
 	var b = new BitBuffer(10)


### PR DESCRIPTION
Import/export buffers as hex string, binary strings, or boolean arrays. 

Create buffer from UInt value up to Number.MAX_SAFE_INTEGER.

Added bitwise shifting and resizing.

Create a subbuffer from the current buffer.

Read numeric values from any bit offset and width of bits. Bits selection is resized before being read so you can get the value of bits that are a non standard number of bytes (including incomplete bytes) from across byte boundaries. 

Mocha no longer seems to be compatible with test.js. Added a test() function to test.js to mocha is no needed to run tests.
