### PR TITLE
Resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+#vscode editor settings
+settings.json

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -2,14 +2,15 @@
 
 function BitBuffer(number, buffer) {
 	var size = Math.ceil(number / 8)
+	
 	if (buffer != undefined && buffer.length == size) {
 		this.buffer = buffer
 	} else {
 		this.buffer = new Buffer(size)
 		this.buffer.fill(0)
 	}
+	this.size = number
 }
-
 
 BitBuffer.prototype = {
 	set: function(index, bool) {
@@ -28,6 +29,52 @@ BitBuffer.prototype = {
 	},
 	toBuffer: function() {
 		return this.buffer
+	},
+	
+	resize: function(newBitSize, propagateSignBit) {
+		var
+			oldBitSize = this.size,
+			oldByteSize = this.buffer.length,
+			newByteSize = Math.ceil(newBitSize / 8),
+			newbuff, lastByte, bit_i;
+
+		if (!isFinite(newByteSize)) {
+			return this
+		}
+		
+		//check if both sign propagation flag and sign bit are set
+		propagateSignBit = propagateSignBit & this.get(oldBitSize - 1)
+		
+		if (newByteSize > oldByteSize) {
+			newbuff = new Buffer(newByteSize)
+			newbuff.fill(0)
+			
+			this.buffer.copy(newbuff, 0, 0, oldByteSize)
+			this.buffer = newbuff
+
+		} else {
+			//We are shirinking the buffer, instead of creating a new buffer 
+			//and copying, we can just take the slice of the data we need.
+			this.buffer = this.buffer.slice(0, newByteSize)
+		}
+
+		//update the size properties
+		this.size = newBitSize
+
+		if (newBitSize % 8 != 0) {
+			//zero out any bits beyond the specified size in the last byte
+			lastByte = newBitSize >>> 3
+			newbuff[lastByte] = newbuff[lastByte] & (Math.pow(2, newBitSize)-1)
+		}
+		
+		//flip all of the leading bits if we are propagating sign
+		if (propagateSignBit) {
+			bit_i = oldBitSize
+			while (bit_i < newBitSize) {
+				this.set(bit_i++, 1)
+			}
+		}
+		return this
 	}
 }
 

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -64,7 +64,7 @@ BitBuffer.prototype = {
 		if (newBitSize % 8 != 0) {
 			//zero out any bits beyond the specified size in the last byte
 			lastByte = newBitSize >>> 3
-			newbuff[lastByte] = newbuff[lastByte] & (Math.pow(2, newBitSize)-1)
+			this[lastByte] = this[lastByte] & (Math.pow(2, newBitSize)-1)
 		}
 		
 		//flip all of the leading bits if we are propagating sign


### PR DESCRIPTION
Resize BitBuffer to any number of bits. Shrinking takes a slice of the original Buffer, growing allocates a new Buffer and copies the contents.
