### PR TITLE
Shifters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+#vscode editor settings
+settings.json

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -64,6 +64,44 @@ BitBuffer.prototype = {
 		}
 		
 		return bitarr
+	},
+	
+	shiftRight: function(shiftBits) {
+		if (shiftBits < 0) {
+			return this.shiftLeft(-shiftBits)
+		}
+		
+		var bitarr = this.toBitArray()
+		
+		while (shiftBits--) {
+			//shift the bits off the "front" of the array
+			//array index 0 is at the front, which corresponds to 
+			//LSB on the right of the bit string
+			bitarr.shift()
+			bitarr.push(0)
+		}
+		
+		this.fromBitArray(bitarr)
+		
+		return this
+	},
+	shiftLeft: function(shiftBits) {
+		if (shiftBits < 0) {
+			return this.shiftRight(-shiftBits)
+		}
+		
+		var bitarr = this.toBitArray()
+		
+		while (shiftBits--) {
+			//unshift empty bits onto the front of the array
+			//and pop the extra bit off the end
+			bitarr.unshift(0)
+			bitarr.pop()
+		}
+		
+		this.fromBitArray(bitarr)
+		
+		return this
 	}
 }
 

--- a/bitbuffer.js
+++ b/bitbuffer.js
@@ -2,12 +2,14 @@
 
 function BitBuffer(number, buffer) {
 	var size = Math.ceil(number / 8)
+	
 	if (buffer != undefined && buffer.length == size) {
 		this.buffer = buffer
 	} else {
 		this.buffer = new Buffer(size)
 		this.buffer.fill(0)
 	}
+	this.size = number
 }
 
 
@@ -28,6 +30,40 @@ BitBuffer.prototype = {
 	},
 	toBuffer: function() {
 		return this.buffer
+	},
+	fromBitArray: function(bitarr, noresize) {
+		var bitSize = bitarr.length, byteSize = Math.ceil(bitSize / 8)
+
+		//clear out the buffer
+		if (noresize || byteSize == this.buffer.length) {
+			this.buffer.fill(0)
+		} else {
+			this.buffer = new Buffer(byteSize)
+			this.buffer.fill(0)
+			this.size = bitSize
+		}
+		
+		bitarr.forEach(function(bit, bit_i){
+			this.set(bit_i, bit)
+		}, this)
+		
+		return this
+	},
+	toBitArray: function(bitOrder) {
+		var size = this.size, maxBit = size - 1, bitarr = []
+		
+		if (bitOrder < 0) {
+			//bitOrder can be set to a negative number to reverse the bit array
+			for (var bit_i = 0; bit_i < size; bit_i++) {
+				bitarr[maxBit - bit_i] = +!!this.get(bit_i)
+			}
+		} else {
+			for (var bit_i = 0; bit_i < size; bit_i++) {
+				bitarr[bit_i] = +!!this.get(bit_i)
+			}
+		}
+		
+		return bitarr
 	}
 }
 


### PR DESCRIPTION
Added functions to shift BitBuffer to the left or right. By default the buffer remains the same size and bits are shifted off one end and zeros are shifted in from the other. An optional boolean argument will resize the array.

Requires to/fromBitArray functions so pull request #6 is included here. 
